### PR TITLE
For loop for clarity and to reduce bug potential

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -144,46 +144,12 @@ if is_play $BUILD_DIR ; then
   fi
   if [ -d $BUILD_DIR/modules/platform/target ] ; then
     echo "-----> Dropping extra directories from the slug"
-    rm -rf $BUILD_DIR/modules/admin/target/universal
-    rm -rf $BUILD_DIR/modules/admin/target/scala-*
-    rm -rf $BUILD_DIR/modules/admin/target/streams
-    rm -rf $BUILD_DIR/modules/admin/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/contentcenter/target/universal
-    rm -rf $BUILD_DIR/modules/contentcenter/target/scala-*
-    rm -rf $BUILD_DIR/modules/contentcenter/target/streams
-    rm -rf $BUILD_DIR/modules/contentcenter/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/core/target/universal
-    rm -rf $BUILD_DIR/modules/core/target/scala-*
-    rm -rf $BUILD_DIR/modules/core/target/streams
-    rm -rf $BUILD_DIR/modules/core/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/email/target/universal
-    rm -rf $BUILD_DIR/modules/email/target/scala-*
-    rm -rf $BUILD_DIR/modules/email/target/streams
-    rm -rf $BUILD_DIR/modules/email/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/platform/target/universal
-    rm -rf $BUILD_DIR/modules/platform/target/scala-*
-    rm -rf $BUILD_DIR/modules/platform/target/streams
-    rm -rf $BUILD_DIR/modules/platform/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/search/target/universal
-    rm -rf $BUILD_DIR/modules/search/target/scala-*
-    rm -rf $BUILD_DIR/modules/search/target/streams
-    rm -rf $BUILD_DIR/modules/search/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/stats/target/universal
-    rm -rf $BUILD_DIR/modules/stats/target/scala-*
-    rm -rf $BUILD_DIR/modules/stats/target/streams
-    rm -rf $BUILD_DIR/modules/stats/target/resolution-cache
-    
-    rm -rf $BUILD_DIR/modules/studio/target/universal
-    rm -rf $BUILD_DIR/modules/studio/target/scala-*
-    rm -rf $BUILD_DIR/modules/studio/target/streams
-    rm -rf $BUILD_DIR/modules/studio/target/resolution-cache
-    
+    for name in admin contentcenter core email platform search stats studio; do
+      rm -rf "$BUILD_DIR/modules/$name/target/universal"
+      rm -rf "$BUILD_DIR/modules/$name/target/"scala-*
+      rm -rf "$BUILD_DIR/modules/$name/target/streams"
+      rm -rf "$BUILD_DIR/modules/$name/target/resolution-cache"
+    done
   fi
 fi
 


### PR DESCRIPTION
Common bug warning: Arguments to for loops must not be quoted.

**WRONG**

```
for name in "foo bar baz"; do
```

**RIGHT**

```
for name in foo bar baz; do
```
